### PR TITLE
Fix NL translation

### DIFF
--- a/po/NL.po
+++ b/po/NL.po
@@ -15,8 +15,8 @@ msgstr ""
 "Last-Translator: Sjoerd Hemminga <sjoerd@huiswerkservice.nl>\n"
 "Language-Team: NL <NL@li.org>\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
-"Content-Transfer-Encoding: ENCODING\n"
+"Content-Type: text/plain; charset=ASCII\n"
+"Content-Transfer-Encoding: 8bit\n"
 
 #: rotix.c:134 rotix.c:145 rotix.c:185
 msgid "rotix: you cannot specify both an inputfile and a text\n"


### PR DESCRIPTION
Avoids the following error:
```
po/NL.po: warning: Charset "CHARSET" is not a portable encoding name.
                 Message conversion to user's charset might not work.
```